### PR TITLE
Add profile sections for books and podcasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
       </p>
     </section>
 
-    <section class="content-section mb-5" data-aos="fade-left">
-      <h3 class="mb-3">Highlights &amp; Achievements</h3>
+      <section class="content-section mb-5" data-aos="fade-left">
+        <h3 class="mb-3">Highlights &amp; Achievements</h3>
       <ul class="list-group list-group-flush">
         <li class="list-group-item"><strong>Strategic Portfolio Analyst at ADQ:</strong> Supported portfolio strategy and investment analysis at one of the UAE’s leading holding companies.</li>
         <li class="list-group-item"><strong>ESG Contributor:</strong> Passionate about integrating sustainability into financial strategy, with exposure to ESG-aligned projects and reporting.</li>
@@ -59,7 +59,32 @@
         <li class="list-group-item"><strong>Active Member of CFA Society Emirates:</strong> Engages in financial literacy and community initiatives within the UAE finance community.</li>
         <li class="list-group-item"><strong>MBA Graduate:</strong> Specialized in Finance, with hands-on exposure to corporate valuation, strategic growth planning, and financial modeling.</li>
       </ul>
-    </section>
+      </section>
+
+      <section class="content-section mb-5" data-aos="fade-right">
+        <h3 class="mb-3">Books Written</h3>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item"><strong>Leading with Empathy:</strong> A guide to building culture-driven organizations.</li>
+          <li class="list-group-item"><strong>Knowledge in Action:</strong> Strategies for fostering continuous learning.</li>
+        </ul>
+      </section>
+
+      <section class="content-section mb-5" data-aos="fade-left">
+        <h3 class="mb-3">Podcasts Attended</h3>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item"><strong>"Culture Catalyst":</strong> Discussed transformative people strategies.</li>
+          <li class="list-group-item"><strong>"The Knowledge Hub":</strong> Shared insights on organizational learning.</li>
+        </ul>
+      </section>
+
+      <section class="content-section mb-5" data-aos="fade-right">
+        <h3 class="mb-3">Head of People, Knowledge &amp; Culture</h3>
+        <p>
+          I lead initiatives that empower teams through collaborative learning,
+          inclusive policies, and a vibrant workplace culture. My mission is to build
+          environments where people thrive and knowledge flows freely across the organization.
+        </p>
+      </section>
 
     <section class="text-center" data-aos="zoom-in">
       <p>


### PR DESCRIPTION
## Summary
- expand the profile page with new sections
- list books written and podcasts attended
- include a short description for the role "Head of People, Knowledge & Culture"

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bd86b8ad08331a2e8a2df8eaf4c94